### PR TITLE
db: thread: Fix 'oldest subject' thread names

### DIFF
--- a/alot/db/thread.py
+++ b/alot/db/thread.py
@@ -47,8 +47,8 @@ class Thread:
             subject = thread.subject
         elif subject_type == 'oldest':
             try:
-                first_msg = list(thread.get_toplevel_messages())[0]
-                subject = first_msg.get_header('subject')
+                first_msg = list(thread.toplevel())[0]
+                subject = first_msg.header('subject')
             except IndexError:
                 subject = ''
         self._subject = subject


### PR DESCRIPTION
The notmuch2 bindings change now means the retrieval of the oldest
subject from a thread needs to be reworked.

When the config option is chosen to use the oldest subject:
  # Set thread subjects to the first (oldest) message
  thread_subject = oldest

The following error is generated:

    File "/home/kbingham/iob/alot/alot/db/thread.py", line 50, in _refresh
      first_msg = list(thread.get_toplevel_messages())[0]
  AttributeError: 'Thread' object has no attribute 'get_toplevel_messages'

Update the code to use the correct interface on both the Thread and
Message objects.

Signed-off-by: Kieran Bingham <kieran.bingham@ideasonboard.com>